### PR TITLE
Fix Bugs and Improve Robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # format-commit-msg
+
+A git commit-msg hook that automatically prefixes commits with the ticket ID from your branch name.
+
+## Installation
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/edvent-ai/format-commit-msg
+    rev: v1.0.0
+    hooks:
+      - id: format-commit-msg
+        stages: [commit-msg]
+```
+
+## Branch Naming
+
+Branches must follow the format: `abc-123-description`
+
+The hook extracts the ticket ID (`abc-123`) and prepends it to your commit message as `[ABC-123]`.
+
+## Credits
+
+Based on [bartoszmajsak's gist](https://gist.github.com/bartoszmajsak/1396344).

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!'C:/Program Files/Git/bin/sh.exe'
 #
 # Automatically adds branch name and branch description to every commit message.
 # For excluded branches (like main), enforces that a branch name is prepended.

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -81,7 +81,7 @@ if [[ $BRANCH_EXCLUDED -eq 1 ]]; then
   fi
 elif [[ "$BRANCH_NAME" =~ $VALID_BRANCH_REGEX ]]; then
   # Valid feature branch - auto-prepend if needed
-  if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
+  if ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       sed -i '' -e "1s:^:[$TICKET_ID] :" "$1"
     else

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -24,7 +24,7 @@ fi
 
 # This way you can customize which branches should be skipped when
 # prepending commit message.
-if [ -z "$BRANCHES_TO_SKIP" ]; then
+if [[ -z "${BRANCHES_TO_SKIP:-}" ]]; then
   BRANCHES_TO_SKIP=(master production staging main bangkok-pc)
 fi
 
@@ -33,7 +33,7 @@ BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 # ===== SKIP DETACHED HEAD =====
 # Skip if in detached HEAD state (rebase, bisect, cherry-pick, etc.)
-if [ "$BRANCH_NAME" = "HEAD" ]; then
+if [[ "$BRANCH_NAME" == "HEAD" ]]; then
   exit 0
 fi
 # ===== END DETACHED HEAD CHECK =====

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -39,7 +39,7 @@ fi
 # ===== END DETACHED HEAD CHECK =====
 
 # Select ticket id from branch name and capitalize it
-TICKET_ID=$(echo $BRANCH_NAME | sed -e 's:^\([^-]*-[^-]*\).*:\1:' -e \
+TICKET_ID=$(echo "$BRANCH_NAME" | sed -e 's:^\([^-]*-[^-]*\).*:\1:' -e \
     'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/')
 
 # Regex to check the valid branch name (allows numbers in first part)

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -39,10 +39,10 @@ BRANCH_PREFIX_REGEX="^\[[a-zA-Z0-9]+-[a-zA-Z0-9]+\]"
 BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
 
 # Whether the commit message has a TICKET_ID
-BRANCH_IN_COMMIT=$(grep -c "$TICKET_ID" $1)
+BRANCH_IN_COMMIT=$(grep -c "$TICKET_ID" "$1")
 
 # Get the first line of the commit message
-COMMIT_MSG=$(head -n 1 $1)
+COMMIT_MSG=$(head -n 1 "$1")
 
 # Check if branch is excluded (like main)
 if [[ $BRANCH_EXCLUDED -eq 1 ]]; then
@@ -69,7 +69,7 @@ if [[ $BRANCH_EXCLUDED -eq 1 ]]; then
 elif [[ "$BRANCH_NAME" =~ $VALID_BRANCH_REGEX ]]; then
   # Valid feature branch - auto-prepend if needed
   if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
-    sed -i -e "1s:^:[$TICKET_ID] :" $1
+    sed -i -e "1s:^:[$TICKET_ID] :" "$1"
   fi
 else
   # Invalid branch name

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 #
 # Automatically adds branch name and branch description to every commit message.
 # For excluded branches (like main), enforces that a branch name is prepended.

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 #
+# Exit codes:
+#   0 - Success (commit proceeds)
+#   1 - Error (commit blocked)
+#
 # Automatically adds branch name and branch description to every commit message.
 # For excluded branches (like main), enforces that a branch name is prepended.
 # Modified from the gist here https://gist.github.com/bartoszmajsak/1396344

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -25,6 +25,13 @@ fi
 # Get branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
+# ===== SKIP DETACHED HEAD =====
+# Skip if in detached HEAD state (rebase, bisect, cherry-pick, etc.)
+if [ "$BRANCH_NAME" = "HEAD" ]; then
+  exit 0
+fi
+# ===== END DETACHED HEAD CHECK =====
+
 # Select ticket id from branch name and capitalize it
 TICKET_ID=$(echo $BRANCH_NAME | sed -e 's:^\([^-]*-[^-]*\).*:\1:' -e \
     'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/')

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -6,9 +6,15 @@ set -euo pipefail
 # Modified from the gist here https://gist.github.com/bartoszmajsak/1396344
 #
 
+# Validate commit message file argument
+if [[ -z "${1:-}" ]] || [[ ! -f "$1" ]]; then
+  echo "Error: Invalid or missing commit message file" >&2
+  exit 1
+fi
+
 # ===== SKIP MERGE COMMITS =====
 # Check if commit message starts with "Merge" (merge commits)
-if [ -f "$1" ]; then
+if [[ -f "$1" ]]; then
   FIRST_LINE=$(head -n 1 "$1")
   if [[ "$FIRST_LINE" =~ ^Merge[[:space:]] ]]; then
     exit 0

--- a/format-commit-msg.sh
+++ b/format-commit-msg.sh
@@ -82,7 +82,11 @@ if [[ $BRANCH_EXCLUDED -eq 1 ]]; then
 elif [[ "$BRANCH_NAME" =~ $VALID_BRANCH_REGEX ]]; then
   # Valid feature branch - auto-prepend if needed
   if [ -n "$BRANCH_NAME" ] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then
-    sed -i -e "1s:^:[$TICKET_ID] :" "$1"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      sed -i '' -e "1s:^:[$TICKET_ID] :" "$1"
+    else
+      sed -i -e "1s:^:[$TICKET_ID] :" "$1"
+    fi
   fi
 else
   # Invalid branch name


### PR DESCRIPTION
## Summary
- Fix cross-platform compatibility (sed -i works on both macOS and Linux)
- Add robustness improvements: strict error handling, input validation, detached HEAD handling, variable quoting
- Add minimal README with installation instructions

## Initial Problems
- Failing when local path to repo has space in path. Cause: path variable ($1) unquoted.
- Failing when in a detached HEAD state e.g. rebase. Cause: this pre-commit hook runs even for rebasing (no new commit messages, no formatting needed).

## Changes

### Bug fixes:
- Fix sed -i portability - macOS requires sed -i '' while Linux uses sed -i
- Quote all file path variables to handle paths with spaces
- Skip running when `BRANCH_NAME == HEAD` (detached HEAD state e.g. rebase)

### Robustness:
- Add `set -euo pipefail` for strict error handling
- Validate commit message file argument before processing

### Code quality:
- Remove redundant `BRANCH_NAME` empty check (already validated by regex)
- Standardize on bash `[[ ]]` bracket style throughout
- Remove unused Windows shebang comment
- Document exit code conventions (0 = success, 1 = error)